### PR TITLE
[ONB-58] API Spec 변경 수정

### DIFF
--- a/data/src/main/java/com/yapp/bol/data/datasource/game/GameDataSource.kt
+++ b/data/src/main/java/com/yapp/bol/data/datasource/game/GameDataSource.kt
@@ -6,5 +6,5 @@ import kotlinx.coroutines.flow.Flow
 
 interface GameDataSource {
 
-    fun getGameList(groupId: Int): Flow<ApiResult<GameApiResponse>>
+    fun getGameList(groupId: Int, sort: String): Flow<ApiResult<GameApiResponse>>
 }

--- a/data/src/main/java/com/yapp/bol/data/datasource/game/GameDataSourceImpl.kt
+++ b/data/src/main/java/com/yapp/bol/data/datasource/game/GameDataSourceImpl.kt
@@ -12,8 +12,11 @@ class GameDataSourceImpl @Inject constructor(
     private val gameApi: GameApi,
 ) : BaseRepository(), GameDataSource {
 
-    override fun getGameList(groupId: Int): Flow<ApiResult<GameApiResponse>> = flow {
-        val result = safeApiCall { gameApi.getGameList(groupId) }
+    override fun getGameList(
+        groupId: Int,
+        sort: String,
+    ): Flow<ApiResult<GameApiResponse>> = flow {
+        val result = safeApiCall { gameApi.getGameList(groupId, sort) }
         emit(result)
     }
 }

--- a/data/src/main/java/com/yapp/bol/data/model/group/GroupDetailResponse.kt
+++ b/data/src/main/java/com/yapp/bol/data/model/group/GroupDetailResponse.kt
@@ -6,7 +6,7 @@ data class GroupDetailResponse(
     val description: String,
     val organization: String,
     val profileImageUrl: String,
-    val accessCode: String,
+    val accessCode: String?,
     val memberCount: Int,
     val owner: OwnerDTO
 )

--- a/data/src/main/java/com/yapp/bol/data/remote/GameApi.kt
+++ b/data/src/main/java/com/yapp/bol/data/remote/GameApi.kt
@@ -4,11 +4,13 @@ import com.yapp.bol.data.model.game.GameApiResponse
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface GameApi {
 
     @GET("/v1/group/{groupId}/game")
     suspend fun getGameList(
         @Path("groupId") groupId: Int,
+        @Query("sort") sort: String,
     ): Response<GameApiResponse>
 }

--- a/data/src/main/java/com/yapp/bol/data/repository/GameRepositoryImpl.kt
+++ b/data/src/main/java/com/yapp/bol/data/repository/GameRepositoryImpl.kt
@@ -4,8 +4,8 @@ import com.yapp.bol.data.datasource.game.GameDataSource
 import com.yapp.bol.data.mapper.GameMapper.gameToDomain
 import com.yapp.bol.domain.model.ApiResult
 import com.yapp.bol.domain.model.GameItem
+import com.yapp.bol.domain.model.GameSortType
 import com.yapp.bol.domain.repository.GameRepository
-import com.yapp.bol.domain.repository.GameSortType
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject

--- a/data/src/main/java/com/yapp/bol/data/repository/GameRepositoryImpl.kt
+++ b/data/src/main/java/com/yapp/bol/data/repository/GameRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.yapp.bol.data.mapper.GameMapper.gameToDomain
 import com.yapp.bol.domain.model.ApiResult
 import com.yapp.bol.domain.model.GameItem
 import com.yapp.bol.domain.repository.GameRepository
+import com.yapp.bol.domain.repository.GameSortType
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -13,8 +14,8 @@ class GameRepositoryImpl @Inject constructor(
     private val gameDataSource: GameDataSource,
 ) : GameRepository {
 
-    override fun getGameList(groupId: Int): Flow<ApiResult<List<GameItem>>> {
-        return gameDataSource.getGameList(groupId).map {
+    override fun getGameList(groupId: Int, sort: GameSortType): Flow<ApiResult<List<GameItem>>> {
+        return gameDataSource.getGameList(groupId, sort.value).map {
             it.gameToDomain()
         }
     }

--- a/domain/src/main/java/com/yapp/bol/domain/model/GameSortType.kt
+++ b/domain/src/main/java/com/yapp/bol/domain/model/GameSortType.kt
@@ -1,0 +1,6 @@
+package com.yapp.bol.domain.model
+
+enum class GameSortType(val value: String) {
+    MATCH_COUNT("MATCH_COUNT"),
+    FIXED("FIXED"),
+}

--- a/domain/src/main/java/com/yapp/bol/domain/model/GroupDetailItem.kt
+++ b/domain/src/main/java/com/yapp/bol/domain/model/GroupDetailItem.kt
@@ -6,7 +6,7 @@ data class GroupDetailItem(
     val description: String,
     val organization: String,
     val profileImageUrl: String,
-    val accessCode: String,
+    val accessCode: String?,
     val memberCount: Int,
     val owner: OwnerItem,
 ) {

--- a/domain/src/main/java/com/yapp/bol/domain/repository/GameRepository.kt
+++ b/domain/src/main/java/com/yapp/bol/domain/repository/GameRepository.kt
@@ -9,4 +9,3 @@ interface GameRepository {
 
     fun getGameList(groupId: Int, sort: GameSortType = GameSortType.FIXED): Flow<ApiResult<List<GameItem>>>
 }
-

--- a/domain/src/main/java/com/yapp/bol/domain/repository/GameRepository.kt
+++ b/domain/src/main/java/com/yapp/bol/domain/repository/GameRepository.kt
@@ -6,5 +6,10 @@ import kotlinx.coroutines.flow.Flow
 
 interface GameRepository {
 
-    fun getGameList(groupId: Int): Flow<ApiResult<List<GameItem>>>
+    fun getGameList(groupId: Int, sort: GameSortType = GameSortType.FIXED): Flow<ApiResult<List<GameItem>>>
+}
+
+enum class GameSortType(val value: String) {
+    MATCH_COUNT("MATCH_COUNT"),
+    FIXED("FIXED"),
 }

--- a/domain/src/main/java/com/yapp/bol/domain/repository/GameRepository.kt
+++ b/domain/src/main/java/com/yapp/bol/domain/repository/GameRepository.kt
@@ -2,6 +2,7 @@ package com.yapp.bol.domain.repository
 
 import com.yapp.bol.domain.model.ApiResult
 import com.yapp.bol.domain.model.GameItem
+import com.yapp.bol.domain.model.GameSortType
 import kotlinx.coroutines.flow.Flow
 
 interface GameRepository {
@@ -9,7 +10,3 @@ interface GameRepository {
     fun getGameList(groupId: Int, sort: GameSortType = GameSortType.FIXED): Flow<ApiResult<List<GameItem>>>
 }
 
-enum class GameSortType(val value: String) {
-    MATCH_COUNT("MATCH_COUNT"),
-    FIXED("FIXED"),
-}

--- a/domain/src/main/java/com/yapp/bol/domain/usecase/group/GetGroupJoinedUseCase.kt
+++ b/domain/src/main/java/com/yapp/bol/domain/usecase/group/GetGroupJoinedUseCase.kt
@@ -1,10 +1,10 @@
 package com.yapp.bol.domain.usecase.group
 
 import com.yapp.bol.domain.model.GameItem
+import com.yapp.bol.domain.model.GameSortType
 import com.yapp.bol.domain.model.GetGroupJoinedItem
 import com.yapp.bol.domain.model.GroupDetailItem
 import com.yapp.bol.domain.repository.GameRepository
-import com.yapp.bol.domain.repository.GameSortType
 import com.yapp.bol.domain.repository.GroupRepository
 import com.yapp.bol.domain.repository.UserRepository
 import com.yapp.bol.domain.utils.doWork

--- a/domain/src/main/java/com/yapp/bol/domain/usecase/group/GetGroupJoinedUseCase.kt
+++ b/domain/src/main/java/com/yapp/bol/domain/usecase/group/GetGroupJoinedUseCase.kt
@@ -4,6 +4,7 @@ import com.yapp.bol.domain.model.GameItem
 import com.yapp.bol.domain.model.GetGroupJoinedItem
 import com.yapp.bol.domain.model.GroupDetailItem
 import com.yapp.bol.domain.repository.GameRepository
+import com.yapp.bol.domain.repository.GameSortType
 import com.yapp.bol.domain.repository.GroupRepository
 import com.yapp.bol.domain.repository.UserRepository
 import com.yapp.bol.domain.utils.doWork
@@ -34,11 +35,11 @@ class GetGroupJoinedUseCase @Inject constructor(
         userRepository.getJoinedGroup().doWork(
             isSuccess = { hasJoinedGroup = hasJoinedGroup(it.map { it.id.toInt() }, groupId) },
         )
-        gameRepository.getGameList(groupId).doWork(
+        gameRepository.getGameList(groupId, GameSortType.MATCH_COUNT).doWork(
             isSuccess = { groupGameList = it },
         )
 
-        gameRepository.getGameList(groupId).doWork(
+        gameRepository.getGameList(groupId, GameSortType.MATCH_COUNT).doWork(
             isSuccess = { groupGameList = it },
         )
 

--- a/domain/src/main/java/com/yapp/bol/domain/usecase/group/GetGroupJoinedUseCase.kt
+++ b/domain/src/main/java/com/yapp/bol/domain/usecase/group/GetGroupJoinedUseCase.kt
@@ -35,9 +35,6 @@ class GetGroupJoinedUseCase @Inject constructor(
         userRepository.getJoinedGroup().doWork(
             isSuccess = { hasJoinedGroup = hasJoinedGroup(it.map { it.id.toInt() }, groupId) },
         )
-        gameRepository.getGameList(groupId, GameSortType.MATCH_COUNT).doWork(
-            isSuccess = { groupGameList = it },
-        )
 
         gameRepository.getGameList(groupId, GameSortType.MATCH_COUNT).doWork(
             isSuccess = { groupGameList = it },

--- a/presentation/src/main/java/com/yapp/bol/presentation/view/home/rank/HomeRankFragment.kt
+++ b/presentation/src/main/java/com/yapp/bol/presentation/view/home/rank/HomeRankFragment.kt
@@ -179,10 +179,15 @@ class HomeRankFragment : BaseFragment<FragmentHomeRankBinding>(R.layout.fragment
                 viewHeader.tvGroupName.text = item.name
                 tvGroupName.text = item.name
                 viewRankNotFound.tvCode.text = item.accessCode
-                viewRankNotFound.btnCodeCopy.setOnClickListener {
-                    item.accessCode.copyToClipboard(root.context)
-                    showToastForAndroid13Below()
-                }
+
+                item.accessCode?.let { code ->
+                    viewRankNotFound.btnCodeCopy.visibility = View.VISIBLE
+                    viewRankNotFound.btnCodeCopy.setOnClickListener {
+                        code.copyToClipboard(root.context)
+                        showToastForAndroid13Below()
+                    }
+                } ?: kotlin.run { viewRankNotFound.btnCodeCopy.visibility = View.INVISIBLE }
+
             }
         }
     }

--- a/presentation/src/main/java/com/yapp/bol/presentation/view/home/rank/HomeRankFragment.kt
+++ b/presentation/src/main/java/com/yapp/bol/presentation/view/home/rank/HomeRankFragment.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.view.View
 import android.widget.Toast
 import androidx.core.view.GravityCompat
+import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.navigation.findNavController
@@ -175,19 +176,16 @@ class HomeRankFragment : BaseFragment<FragmentHomeRankBinding>(R.layout.fragment
 
     private fun setCurrentGroupInfo(currentGroupInfo: DrawerGroupInfoUiModel.CurrentGroupInfo) {
         binding.apply {
-            currentGroupInfo.groupDetailItem.let { item ->
-                viewHeader.tvGroupName.text = item.name
-                tvGroupName.text = item.name
-                viewRankNotFound.tvCode.text = item.accessCode
-
-                item.accessCode?.let { code ->
-                    viewRankNotFound.btnCodeCopy.visibility = View.VISIBLE
-                    viewRankNotFound.btnCodeCopy.setOnClickListener {
-                        code.copyToClipboard(root.context)
-                        showToastForAndroid13Below()
-                    }
-                } ?: kotlin.run { viewRankNotFound.btnCodeCopy.visibility = View.INVISIBLE }
-
+            val item = currentGroupInfo.groupDetailItem
+            viewHeader.tvGroupName.text = item.name
+            tvGroupName.text = item.name
+            viewRankNotFound.tvCode.text = item.accessCode
+            viewRankNotFound.btnCodeCopy.isVisible = item.accessCode != null
+            item.accessCode?.let { code ->
+                viewRankNotFound.btnCodeCopy.setOnClickListener {
+                    code.copyToClipboard(root.context)
+                    showToastForAndroid13Below()
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/yapp/bol/presentation/view/home/rank/group_info/DrawerCurrentGroupInfoViewHolder.kt
+++ b/presentation/src/main/java/com/yapp/bol/presentation/view/home/rank/group_info/DrawerCurrentGroupInfoViewHolder.kt
@@ -30,8 +30,10 @@ class DrawerCurrentGroupInfoViewHolder(
     }
 
     private fun ItemGroupInfoDetailBinding.setOnClickListener(groupDetailItem: GroupDetailItem) {
-        btnCopy.setOnClickListener { onClick(groupDetailItem.accessCode) }
-        tvCode.setOnClickListener { onClick(groupDetailItem.accessCode) }
+        groupDetailItem.accessCode?.let { code ->
+            btnCopy.setOnClickListener { onClick(code) }
+            tvCode.setOnClickListener { onClick(code) }
+        }
     }
 
     companion object {


### PR DESCRIPTION
## Changes
- 그룹의 게임 목록 불러오는 API의 정렬 기준이 추가되어 해당 부분 수정했습니다! 

<br/>

## 기타 참고 사항
- 파라미터 없이 사용하고 있었기 때문에 기본값을 FIXED로 해두고 매치 수에 따라 게임 목록을 보여줘야 되는 곳에서만 파라미터 넣어주는 방식으로 수정했습니다. 근데 이 정렬 타입 자체가 비즈니스 로직은 맞는데 enum을 도메인 모듈에 넣어야 될지 말아야 할지 고민을 좀 많이 했는데,, 음 일단 넣긴 했는데 요건 재홍님 의견도 궁금합니다! 

<br/>

## Reference
- [Jira Ticket](https://onboardgame.atlassian.net/browse/ONB-58)


<br/>

<details>
<summary> <b> :page_facing_up: 리뷰 시 참고 사항 </b>  </summary>
<div markdown="1">

P1: 꼭 반영해주세요 (Request changes)
P2: 적극적으로 고려해주세요 (Request changes)
P3: 웬만하면 반영해 주세요 (Comment)
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
P5: 그냥 사소한 의견입니다 (Approve)

</div>
</details>
