### PR TITLE
[ONB-154] 홈으로부터 그룹 둘러보기 & 참여 fragment 분리 

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -24,7 +24,8 @@
             android:exported="false" />
         <activity
             android:name=".view.home.HomeActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:launchMode="singleTask" />
         <activity
             android:name=".view.login.splash.SplashActivity"
             android:exported="false"

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -9,6 +9,9 @@
 
     <application>
         <activity
+            android:name=".view.group.GroupDiscoveryActivity"
+            android:exported="false" />
+        <activity
             android:name=".view.mypage.SettingActivity"
             android:exported="false"
             android:windowSoftInputMode="adjustResize" />

--- a/presentation/src/main/java/com/yapp/bol/presentation/view/group/GroupDiscoveryActivity.kt
+++ b/presentation/src/main/java/com/yapp/bol/presentation/view/group/GroupDiscoveryActivity.kt
@@ -1,0 +1,9 @@
+package com.yapp.bol.presentation.view.group
+
+import com.yapp.bol.presentation.R
+import com.yapp.bol.presentation.base.BaseActivity
+import com.yapp.bol.presentation.databinding.ActivityGroupDiscoveryBinding
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class GroupDiscoveryActivity : BaseActivity<ActivityGroupDiscoveryBinding>(R.layout.activity_group_discovery)

--- a/presentation/src/main/java/com/yapp/bol/presentation/view/group/join/GroupJoinFragment.kt
+++ b/presentation/src/main/java/com/yapp/bol/presentation/view/group/join/GroupJoinFragment.kt
@@ -244,13 +244,7 @@ class GroupJoinFragment : Fragment() {
 
     private fun moveHomeActivity() {
         val groupId = viewModel.groupId.toLong()
-        when (activity) {
-            is HomeActivity -> {
-                findNavController().navigate(R.id.action_groupJoinFragment_to_homeRankFragment)
-                homeViewModel.groupId = groupId
-                homeViewModel.gameId = null
-            }
-        }
+        HomeActivity.startActivity(binding.root.context, groupId)
     }
 
     private fun subscribeObservables() {

--- a/presentation/src/main/java/com/yapp/bol/presentation/view/group/search/GroupSearchFragment.kt
+++ b/presentation/src/main/java/com/yapp/bol/presentation/view/group/search/GroupSearchFragment.kt
@@ -168,7 +168,7 @@ class GroupSearchFragment : BaseFragment<FragmentGroupSearchBinding>(R.layout.fr
 
     private fun setBackButton() {
         binding.btnBack.setOnClickListener {
-            binding.root.findNavController().popBackStack()
+            requireActivity().finish()
         }
     }
 }

--- a/presentation/src/main/java/com/yapp/bol/presentation/view/home/rank/HomeRankFragment.kt
+++ b/presentation/src/main/java/com/yapp/bol/presentation/view/home/rank/HomeRankFragment.kt
@@ -9,7 +9,6 @@ import androidx.core.view.GravityCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
-import androidx.navigation.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.SCROLL_STATE_IDLE
@@ -24,6 +23,7 @@ import com.yapp.bol.presentation.utils.collectWithLifecycle
 import com.yapp.bol.presentation.utils.copyToClipboard
 import com.yapp.bol.presentation.utils.setStatusBarColor
 import com.yapp.bol.presentation.utils.showToast
+import com.yapp.bol.presentation.view.group.GroupDiscoveryActivity
 import com.yapp.bol.presentation.view.home.HomeUiState
 import com.yapp.bol.presentation.view.home.HomeViewModel
 import com.yapp.bol.presentation.view.home.rank.UserRankViewModel.Companion.RV_SELECTED_POSITION_RESET
@@ -50,7 +50,7 @@ class HomeRankFragment : BaseFragment<FragmentHomeRankBinding>(R.layout.fragment
         GroupChangeDialog(
             onGroupClick = { viewModel.fetchAll(it) },
             onSearchGroupClick = {
-                binding.root.findNavController().navigate(R.id.action_homeRankFragment_to_groupSearchFragment)
+                moveToGroupDiscovery()
             }
         )
     }
@@ -102,8 +102,11 @@ class HomeRankFragment : BaseFragment<FragmentHomeRankBinding>(R.layout.fragment
         }
     }
 
-    private fun navigateToGroupSearchFragment() {
-        binding.root.findNavController().navigate(R.id.action_homeRankFragment_to_groupSearchFragment)
+    private fun moveToGroupDiscovery() {
+        // todo 잘 돌아가는지 체크 필요
+        Intent(binding.root.context, GroupDiscoveryActivity::class.java).apply {
+            startActivity(this)
+        }
     }
 
     private fun setHomeRecyclerView() {
@@ -414,7 +417,7 @@ class HomeRankFragment : BaseFragment<FragmentHomeRankBinding>(R.layout.fragment
 
     private fun setGroupSearchButton() {
         binding.viewNoJoinedGroup.btnGroupSearch.setOnClickListener {
-            navigateToGroupSearchFragment()
+            moveToGroupDiscovery()
         }
     }
 

--- a/presentation/src/main/res/layout/activity_group_discovery.xml
+++ b/presentation/src/main/res/layout/activity_group_discovery.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".view.group.GroupDiscoveryActivity">
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/group_discovery_nav_host"
+            android:name="androidx.navigation.fragment.NavHostFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:defaultNavHost="true"
+            app:navGraph="@navigation/group_discover_nav_graph"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/navigation/group_discover_nav_graph.xml
+++ b/presentation/src/main/res/navigation/group_discover_nav_graph.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/group_discover_nav_graph"
+    app:startDestination="@id/searchFragment">
+
+    <fragment
+        android:id="@+id/searchFragment"
+        android:name="com.yapp.bol.presentation.view.group.search.GroupSearchFragment"
+        android:label="searchFragment" >
+        <action
+            android:id="@+id/action_groupSearchFragment_to_groupJoinFragment"
+            app:destination="@id/groupJoinFragment"
+            app:enterAnim="@animator/enter_from_right"
+            app:exitAnim="@animator/exit_to_left"
+            app:popEnterAnim="@animator/enter_from_left"
+            app:popExitAnim="@animator/exit_to_right"/>
+    </fragment>
+
+    <fragment
+        android:id="@+id/groupJoinFragment"
+        android:name="com.yapp.bol.presentation.view.group.join.GroupJoinFragment"
+        android:label="GroupJoinFragment" >
+    </fragment>
+
+</navigation>


### PR DESCRIPTION
## Changes
- 저 두 fragment가 홈이랑 분리되어 있지 않아서 피그마, 기획이랑 다르게 바텀 네비게이션이 두 화면에서 계속 보였습니다. 그래서 아예 분리해서 해결했고 154번 티켓도 자연스럽게 해결되었습니다.

<br/>

## 기타 참고 사항
-

<br/>

## Reference
- [Jira Ticket](https://onboardgame.atlassian.net/browse/ONB-154)

<br/>

<details>
<summary> <b> :page_facing_up: 리뷰 시 참고 사항 </b>  </summary>
<div markdown="1">

P1: 꼭 반영해주세요 (Request changes)
P2: 적극적으로 고려해주세요 (Request changes)
P3: 웬만하면 반영해 주세요 (Comment)
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
P5: 그냥 사소한 의견입니다 (Approve)

</div>
</details>
